### PR TITLE
Allow more versions of node to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "standard-version": "^4.4.0"
   },
   "engines": {
-    "node": "8.9.0",
+    "node": ">8.9.0 <10",
     "npm": "5.5.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "standard-version": "^4.4.0"
   },
   "engines": {
-    "node": ">8.9.0 <10",
+    "node": ">=8.9.0 <10",
     "npm": "5.5.1"
   },
   "keywords": [


### PR DESCRIPTION
Pinning to a very specific version of node makes integrating probot-support difficult in self-hosted setups.